### PR TITLE
fix: avoid PySide crash from QProcess finished after deleteLater

### DIFF
--- a/qgitc/datafetcher.py
+++ b/qgitc/datafetcher.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from PySide6.QtCore import SIGNAL, QObject, QProcess, QProcessEnvironment, Signal
+from PySide6.QtCore import QObject, QProcess, QProcessEnvironment, Signal
 
 from qgitc.common import logger
 from qgitc.gitutils import Git, GitProcess
@@ -18,10 +18,11 @@ class DataFetcher(QObject):
         self._errorData = b''
         self._cwd = None
         self._exitCode = 0
+        self._active = False
 
     @property
     def process(self):
-        return self._process
+        return self._process if self._active else None
 
     @property
     def dataChunk(self):
@@ -51,7 +52,19 @@ class DataFetcher(QObject):
         """Implement in subclass"""
         pass
 
+    def _ensureProcess(self):
+        if self._process is not None:
+            return
+
+        # Reuse one QProcess; deleteLater after finished crashes PySide
+        self._process = QProcess(self)
+        self._process.readyReadStandardOutput.connect(self.onDataAvailable)
+        self._process.readyReadStandardError.connect(self.onProcessError)
+        self._process.finished.connect(self.onDataFinished)
+
     def onDataAvailable(self):
+        if not self._active or not self._process:
+            return
         data = self._process.readAllStandardOutput().data()
         if self._dataChunk:
             data = self._dataChunk + data
@@ -72,43 +85,36 @@ class DataFetcher(QObject):
             self.parse(data)
 
     def onProcessError(self):
-        if not self._process:
+        if not self._active or not self._process:
             return
         data = self._process.readAllStandardError().data()
         self._errorData += data
 
     def onDataFinished(self, exitCode, exitStatus):
+        if not self._active:
+            return
+        # Stale finished from cancel/kill after the next start()
+        if self._process.state() != QProcess.NotRunning:
+            return
+
+        self._active = False
         if self._dataChunk:
             self.parse(self._dataChunk)
+            self._dataChunk = None
 
-        if self._process:
-            self._cleanup()
-            self._process.deleteLater()
-        self._process = None
         self._exitCode = exitCode
         self.fetchFinished.emit(exitCode)
-
-    def _cleanup(self):
-        QObject.disconnect(self._process,
-                            SIGNAL("readyReadStandardOutput()"),
-                            self.onDataAvailable)
-        QObject.disconnect(self._process,
-                            SIGNAL("finished(int, QProcess::ExitStatus)"),
-                            self.onDataFinished)
-        QObject.disconnect(self._process, SIGNAL("readyReadStandardError()"),
-                            self.onProcessError)
-        self._process.close()
 
     def cancel(self):
         if self._process:
             logger.info("Cancel git process")
-            # self._process.disconnect(self)
-            self._cleanup()
-            self._process.waitForFinished(100)
-            if self._process.state() == QProcess.Running:
-                logger.warning("Kill git process")
-                self._process.kill()
-            self._process = None
+            self._active = False
+            if self._process.state() != QProcess.NotRunning:
+                self._process.close()
+                self._process.waitForFinished(100)
+                if self._process.state() == QProcess.Running:
+                    logger.warning("Kill git process")
+                    self._process.kill()
 
         self._dataChunk = None
 
@@ -125,15 +131,13 @@ class DataFetcher(QObject):
 
         git_args = self.makeArgs(args)
 
-        self._process = QProcess()
+        self._ensureProcess()
         cwd = self._cwd if self._cwd else Git.REPO_DIR
         self._process.setWorkingDirectory(cwd)
-        self._process.readyReadStandardOutput.connect(self.onDataAvailable)
-        self._process.readyReadStandardError.connect(self.onProcessError)
-        self._process.finished.connect(self.onDataFinished)
 
         env = QProcessEnvironment.systemEnvironment()
         env.insert("LANGUAGE", "en_US")
         self._process.setProcessEnvironment(env)
 
         self._process.start(GitProcess.GIT_BIN, git_args)
+        self._active = True

--- a/qgitc/gitutils.py
+++ b/qgitc/gitutils.py
@@ -9,7 +9,7 @@ import time
 from collections import defaultdict
 from typing import Dict, List, Union
 
-from PySide6.QtCore import QCoreApplication, QEventLoop, QProcess, QThread
+from PySide6.QtCore import QCoreApplication, QProcess, QThread
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +59,7 @@ class QGitProcess():
         logger.debug(f"run {args} in {repoDir}")
 
         self._text = text
-        self._eventLoop = None
+        self._cancelled = False
 
         process = QProcess()
         process.setWorkingDirectory(repoDir)
@@ -82,20 +82,17 @@ class QGitProcess():
             self._process.waitForStarted(1000)
 
         if self._process.state() == QProcess.Running:
-            # QEventLoop seems not working in ThreadPoolExecutor
+            # Wait without connecting finished (avoid PySide crash)
             if QCoreApplication.instance() is None or QCoreApplication.instance().thread() != QThread.currentThread():
                 self._process.waitForFinished()
             else:
-                assert (self._eventLoop is None)
-                self._eventLoop = QEventLoop()
-                self._process.finished.connect(self._eventLoop.quit)
-                self._eventLoop.exec()
+                while not self._process.waitForFinished(50):
+                    if self._cancelled:
+                        return None, None
+                    QCoreApplication.instance().processEvents()
 
-                # user cancelled
-                if self._eventLoop is None:
+                if self._cancelled:
                     return None, None
-
-                self._eventLoop = None
 
         output = self._process.readAllStandardOutput().data()
         error = self._process.readAllStandardError().data()
@@ -105,15 +102,15 @@ class QGitProcess():
         return output, error
 
     def terminate(self):
-        if not self._eventLoop:
+        if self._cancelled:
             return
 
-        self._eventLoop.quit()
-        self._eventLoop = None
+        self._cancelled = True
 
         self._process.close()
         self._process.waitForFinished(50)
-        self._process.kill()
+        if self._process.state() == QProcess.Running:
+            self._process.kill()
         logger.warning("Git process killed")
 
 

--- a/qgitc/logsfetcherqprocessworker.py
+++ b/qgitc/logsfetcherqprocessworker.py
@@ -27,6 +27,8 @@ class LocalChangesFetcher(QObject):
         self._repoDir = repoDir
         self._lccProcess: QProcess = None
         self._lucProcess: QProcess = None
+        self._lccProcessObj: QProcess = None
+        self._lucProcessObj: QProcess = None
         self._failedStart = set()
         self.isComposite = isComposite
 
@@ -39,13 +41,22 @@ class LocalChangesFetcher(QObject):
         self._lucProcess = self._startProcess(False)
 
     def cancel(self):
-        self._cancelProcess(self._lccProcess)
-        self._cancelProcess(self._lucProcess)
-
+        # Clear active markers first so finished during wait is ignored
+        lccProcess = self._lccProcess
+        lucProcess = self._lucProcess
+        self._lccProcess = None
+        self._lucProcess = None
         self.hasLCC = False
         self.hasLUC = False
-        self._lucProcess = None
-        self._lccProcess = None
+
+        self._cancelProcess(lccProcess)
+        self._cancelProcess(lucProcess)
+
+    def _createProcess(self):
+        process = QProcess(self)
+        process.finished.connect(self._onFinished)
+        process.errorOccurred.connect(self._onError)
+        return process
 
     def _startProcess(self, cached: bool):
         args = ["diff", "--quiet", "-s"]
@@ -54,10 +65,16 @@ class LocalChangesFetcher(QObject):
         if Git.versionGE(1, 7, 2):
             args.append("--ignore-submodules=dirty")
 
-        process = QProcess()
+        if cached:
+            if self._lccProcessObj is None:
+                self._lccProcessObj = self._createProcess()
+            process = self._lccProcessObj
+        else:
+            if self._lucProcessObj is None:
+                self._lucProcessObj = self._createProcess()
+            process = self._lucProcessObj
+
         process.setWorkingDirectory(self._repoDir or Git.REPO_DIR)
-        process.finished.connect(self._onFinished)
-        process.errorOccurred.connect(self._onError)
 
         process.start(GitProcess.GIT_BIN, args)
         if process in self._failedStart:
@@ -69,30 +86,23 @@ class LocalChangesFetcher(QObject):
         if not process:
             return
 
-        LocalChangesFetcher._cleanupProcess(process, delete=False)
-        process.waitForFinished(50)
-        if process.state() == QProcess.Running:
-            logger.warning("Kill git process")
-            process.kill()
-
-    @staticmethod
-    def _cleanupProcess(process: QProcess, delete=True):
-        process.finished.disconnect()
-        process.errorOccurred.disconnect()
-        process.close()
-        if delete:
-            process.deleteLater()
+        if process.state() != QProcess.NotRunning:
+            process.close()
+            process.waitForFinished(50)
+            if process.state() == QProcess.Running:
+                logger.warning("Kill git process")
+                process.kill()
 
     def _onFinished(self, exitCode, exitStatus):
         process: QProcess = self.sender()
         if process == self._lccProcess:
             self.hasLCC = exitCode == 1
             self._lccProcess = None
-        else:
+        elif process == self._lucProcess:
             self.hasLUC = exitCode == 1
             self._lucProcess = None
-
-        LocalChangesFetcher._cleanupProcess(process)
+        else:
+            return
 
         if not self._lccProcess and not self._lucProcess:
             self.finished.emit()


### PR DESCRIPTION
Reuse QProcess in DataFetcher and LocalChangesFetcher instead of deleteLater, and wait in QGitProcess without connecting finished, to prevent qtEmit UAF on Windows PySide6.