### PR TITLE
Fix untracked files handling in composite mode and improve local changes display performance.

### DIFF
--- a/qgitc/diffview.py
+++ b/qgitc/diffview.py
@@ -573,7 +573,7 @@ class DiffView(QWidget):
         for diffType, data in lineItems:
             if diffType == DiffType.File:
                 # Flush previous file chunk
-                if currentFile is not None:
+                if currentFile is not None and currentFile in fileItems:
                     self._pendingDiffs[currentFile] = (currentLines, fileItems[currentFile])
                 # Decode file name from the line data
                 if isinstance(data, bytes):

--- a/qgitc/diffview.py
+++ b/qgitc/diffview.py
@@ -578,6 +578,7 @@ class DiffView(QWidget):
                 self.fetcher.repoDir = commit.repoDir
             else:
                 self.fetcher.cwd = self.branchDir or Git.REPO_DIR
+                self.fetcher.repoDir = None
 
             if commit.sha1 is None:
                 # Untracked file: sha1=None triggers git diff --no-index /dev/null
@@ -595,20 +596,25 @@ class DiffView(QWidget):
                                  self.fetcher.errorData.decode("utf-8"))
 
     def _addUntrackedEntries(self, commit: Commit):
-        untrackedFiles = commit.untrackedFiles
-        if not untrackedFiles:
-            return
+        # Collect untracked files from the top-level commit and all sub-commits.
+        # Each sub-commit carries its own repoDir so we can set the correct cwd
+        # when fetching the diff for its untracked files.
+        owners = [commit] + commit.subCommits
+        for owner in owners:
+            untrackedFiles = owner.untrackedFiles
+            if not untrackedFiles:
+                continue
 
-        repoDir = commit.repoDir
-        for file in untrackedFiles:
-            # Queue via _commitList: sha1=None triggers git diff --no-index.
-            # Difffetcher.parse() will add the file to the list automatically,
-            # and __onDiffAvailable will fix the icon from Added→Untracked.
-            fakeCommit = Commit()
-            fakeCommit.sha1 = None
-            fakeCommit.comments = file
-            fakeCommit.repoDir = repoDir
-            self._commitList.append(fakeCommit)
+            repoDir = owner.repoDir
+            for file in untrackedFiles:
+                # Queue via _commitList: sha1=None triggers git diff --no-index.
+                # Difffetcher.parse() will add the file to the list automatically,
+                # and __onDiffAvailable will fix the icon from Added→Untracked.
+                fakeCommit = Commit()
+                fakeCommit.sha1 = None
+                fakeCommit.comments = file
+                fakeCommit.repoDir = repoDir
+                self._commitList.append(fakeCommit)
 
     def __addToFileListView(self, *args):
         """specify the @row number of the file in the viewer"""

--- a/qgitc/diffview.py
+++ b/qgitc/diffview.py
@@ -43,7 +43,7 @@ from qgitc.applicationbase import ApplicationBase
 from qgitc.commitsource import CommitSource
 from qgitc.common import *
 from qgitc.difffetcher import DiffFetcher
-from qgitc.diffutils import FileInfo, FileState
+from qgitc.diffutils import DiffType, FileInfo, FileState
 from qgitc.gitutils import Git, GitProcess
 from qgitc.patchviewer import PatchViewer
 
@@ -189,6 +189,9 @@ class DiffView(QWidget):
         self.fetcher = DiffFetcher(self)
         # sub commit to fetch
         self._commitList: List[Commit] = []
+        # Diff blocks keyed by file name, collected during fetch and flushed
+        # in sorted order when all fetches complete.
+        self._pendingDiffs: dict = {}
 
         self._commitSource: CommitSource = None
         self._showingCommit = False
@@ -561,8 +564,31 @@ class DiffView(QWidget):
         self.twMenu.exec(self.fileListView.mapToGlobal(pos))
 
     def __onDiffAvailable(self, lineItems, fileItems):
-        self.__addToFileListView(fileItems)
-        self.viewer.appendLines(lineItems)
+        # Split the block into per-file chunks keyed by file name.
+        # Each chunk starts at a DiffType.File marker and includes all lines
+        # until the next File marker. A leading DiffType.Diff separator line
+        # before the first file is discarded.
+        currentFile = None
+        currentLines = []
+        for diffType, data in lineItems:
+            if diffType == DiffType.File:
+                # Flush previous file chunk
+                if currentFile is not None:
+                    self._pendingDiffs[currentFile] = (currentLines, fileItems[currentFile])
+                # Decode file name from the line data
+                if isinstance(data, bytes):
+                    currentFile = data.decode("utf-8", errors="replace")
+                else:
+                    currentFile = data
+                currentLines = [(diffType, data)]
+            else:
+                if currentFile is not None:
+                    currentLines.append((diffType, data))
+                # else: skip leading separator lines before first file
+
+        # Flush last file chunk
+        if currentFile is not None and currentFile in fileItems:
+            self._pendingDiffs[currentFile] = (currentLines, fileItems[currentFile])
 
     def __onDiffFileStateChanged(self, filePath: str, newState: FileState):
         self.fileListModel.updateFileState(filePath, newState)
@@ -588,6 +614,7 @@ class DiffView(QWidget):
             return
 
         self.fetcher.cwd = self.branchDir or Git.REPO_DIR
+        self._flushPendingDiffs()
         self.viewer.endReading()
         self.endFetch.emit()
 
@@ -595,10 +622,28 @@ class DiffView(QWidget):
             QMessageBox.critical(self, self.window().windowTitle(),
                                  self.fetcher.errorData.decode("utf-8"))
 
+    def _flushPendingDiffs(self):
+        """Flush pending diff blocks sorted by file name to viewer + file list."""
+        diffs = self._pendingDiffs
+        self._pendingDiffs = {}
+        if not diffs:
+            return
+
+        row = self.viewer.textLineCount()
+        for fileName in sorted(diffs, key=str.lower):
+            lineItems, info = diffs[fileName]
+            info.row = row
+            self.fileListModel.addFile(fileName, info)
+            self.viewer.appendLines(lineItems)
+            row += len(lineItems)
+
     def _addUntrackedEntries(self, commit: Commit):
         # Collect untracked files from the top-level commit and all sub-commits.
         # Each sub-commit carries its own repoDir so we can set the correct cwd
         # when fetching the diff for its untracked files.
+        # Sort all untracked entries by file name so they appear in alphabetical
+        # order in both the file list and the diff viewer.
+        entries = []
         owners = [commit] + commit.subCommits
         for owner in owners:
             untrackedFiles = owner.untrackedFiles
@@ -607,14 +652,19 @@ class DiffView(QWidget):
 
             repoDir = owner.repoDir
             for file in untrackedFiles:
-                # Queue via _commitList: sha1=None triggers git diff --no-index.
-                # Difffetcher.parse() will add the file to the list automatically,
-                # and __onDiffAvailable will fix the icon from Added→Untracked.
-                fakeCommit = Commit()
-                fakeCommit.sha1 = None
-                fakeCommit.comments = file
-                fakeCommit.repoDir = repoDir
-                self._commitList.append(fakeCommit)
+                entries.append((file, repoDir))
+
+        entries.sort(key=lambda e: e[0].lower())
+
+        for file, repoDir in entries:
+            # Queue via _commitList: sha1=None triggers git diff --no-index.
+            # Difffetcher.parse() will add the file to the list automatically,
+            # and __onDiffAvailable will fix the icon from Added→Untracked.
+            fakeCommit = Commit()
+            fakeCommit.sha1 = None
+            fakeCommit.comments = file
+            fakeCommit.repoDir = repoDir
+            self._commitList.append(fakeCommit)
 
     def __addToFileListView(self, *args):
         """specify the @row number of the file in the viewer"""
@@ -779,6 +829,7 @@ class DiffView(QWidget):
     def clear(self):
         self.fileListModel.clear()
         self.viewer.clear()
+        self._pendingDiffs.clear()
         self._updateFilterStatus()
         self.commit = None
         self._delayCommit = None

--- a/qgitc/logsfetcherqprocessworker.py
+++ b/qgitc/logsfetcherqprocessworker.py
@@ -156,6 +156,14 @@ class LogsFetcherQProcessWorker(LogsFetcherWorkerBase):
 
         self._queueTasks = []
 
+        # Track local-changes fetcher completion so localChangesAvailable
+        # can be emitted as soon as all LocalChangesFetchers finish, without
+        # waiting for log fetchers to complete.
+        self._localChangesTotal = 0
+        self._localChangesDone = 0
+        self._localChangesEmitted = False
+        self._compositeSubmodules = []
+
         self._quitEventLoopRequested.connect(
             self._quitEventLoop, Qt.QueuedConnection)
 
@@ -181,6 +189,16 @@ class LogsFetcherQProcessWorker(LogsFetcherWorkerBase):
             self._eventLoop = None
             return
 
+        # Start local-changes fetcher first (fast: git status) so local
+        # changes appear before the log fetch (slow: git log) completes.
+        lcFetcher = None
+        if self.needLocalChanges():
+            lcFetcher = LocalChangesFetcher(self._branchDir, False)
+            lcFetcher.finished.connect(self._onFetchFinished)
+            self._fetchers.append(lcFetcher)
+            lcFetcher.fetch()
+            self._localChangesTotal = 1
+
         fetcher = LogsFetcherImpl()
         fetcher.logsAvailable.connect(
             self.logsAvailable)
@@ -190,13 +208,6 @@ class LogsFetcherQProcessWorker(LogsFetcherWorkerBase):
 
         fetcher.fetch(*self._args)
 
-        lcFetcher = None
-        if self.needLocalChanges():
-            lcFetcher = LocalChangesFetcher(self._branchDir, False)
-            lcFetcher.finished.connect(self._onFetchFinished)
-            self._fetchers.append(lcFetcher)
-            lcFetcher.fetch()
-
         self._eventLoop.exec()
         self._eventLoop = None
 
@@ -205,7 +216,9 @@ class LogsFetcherQProcessWorker(LogsFetcherWorkerBase):
             self._clearFetcher()
             return
 
-        if lcFetcher:
+        # localChangesAvailable was already emitted in _onFetchLocalChangesFinished
+        # as soon as the LocalChangesFetcher finished. Emit here only as a fallback.
+        if not self._localChangesEmitted:
             self.localChangesAvailable.emit(self._lccCommit, self._lucCommit)
 
         self._handleError(fetcher.errorData, fetcher._branch, fetcher.repoDir)
@@ -240,6 +253,15 @@ class LogsFetcherQProcessWorker(LogsFetcherWorkerBase):
                         repoDir = "."
             LogsFetcherWorkerBase._makeLocalCommits(
                 self._lccCommit, self._lucCommit, hasLCC, hasLUC, repoDir, untracked)
+
+        self._localChangesDone += 1
+        # Emit once all local-changes fetchers are done so local changes
+        # appear before log fetchers complete (they started first and are fast).
+        if (self._localChangesTotal > 0
+                and self._localChangesDone >= self._localChangesTotal
+                and not self._localChangesEmitted):
+            self._localChangesEmitted = True
+            self.localChangesAvailable.emit(self._lccCommit, self._lucCommit)
 
     def _onFetchFinished(self):
         if self.isInterruptionRequested():
@@ -278,12 +300,35 @@ class LogsFetcherQProcessWorker(LogsFetcherWorkerBase):
         logsArgs = self._args[1]
         paths = extractFilePaths(logsArgs)
         submodules = filterSubmoduleByPath(self._submodules, paths)
+        self._compositeSubmodules = submodules
 
         self._exitCode = 0
         self._cleanupCompositeEmit()
 
         self._eventLoop = QEventLoop()
         MAX_QUEUE_SIZE = 32
+
+        # Start local-changes fetchers first (they are fast: git status),
+        # then log fetchers (they are slow: git log). Both run concurrently,
+        # but local changes get priority for the limited QProcess slots so
+        # they appear at the top of the list as early as possible.
+        if self.needLocalChanges():
+            for submodule in submodules:
+                if self.isInterruptionRequested():
+                    self._clearFetcher()
+                    self._eventLoop = None
+                    return
+
+                fetcher = LocalChangesFetcher(
+                    fullRepoDir(submodule, self._branchDir), True)
+                fetcher.finished.connect(self._onFetchFinished)
+
+                if len(self._fetchers) < MAX_QUEUE_SIZE:
+                    fetcher.fetch()
+                    self._fetchers.append(fetcher)
+                else:
+                    self._queueTasks.append(fetcher)
+            self._localChangesTotal = len(submodules)
 
         for submodule in submodules:
             if self.isInterruptionRequested():
@@ -301,23 +346,6 @@ class LogsFetcherQProcessWorker(LogsFetcherWorkerBase):
             else:
                 self._queueTasks.append(fetcher)
 
-        if self.needLocalChanges():
-            for submodule in submodules:
-                if self.isInterruptionRequested():
-                    self._clearFetcher()
-                    self._eventLoop = None
-                    return
-
-                fetcher = LocalChangesFetcher(
-                    fullRepoDir(submodule, self._branchDir), True)
-                fetcher.finished.connect(self._onFetchFinished)
-
-                if len(self._fetchers) < MAX_QUEUE_SIZE:
-                    fetcher.fetch()
-                    self._fetchers.append(fetcher)
-                else:
-                    self._queueTasks.append(fetcher)
-
         if self.isInterruptionRequested():
             self._clearFetcher()
             self._eventLoop = None
@@ -327,7 +355,8 @@ class LogsFetcherQProcessWorker(LogsFetcherWorkerBase):
 
         self._eventLoop.exec()
 
-        logger.debug("fetch elapsed: %fs", time.time() - b)
+        logger.debug("fetch elapsed: %fs, localChangesEmitted=%s",
+                     time.time() - b, self._localChangesEmitted)
 
         if self.isInterruptionRequested():
             self._clearFetcher()
@@ -338,7 +367,12 @@ class LogsFetcherQProcessWorker(LogsFetcherWorkerBase):
             return
 
         self._flushCompositeEmit()
-        self.localChangesAvailable.emit(self._lccCommit, self._lucCommit)
+        # localChangesAvailable was already emitted incrementally as each
+        # LocalChangesFetcher finished. Emit here only as a fallback if
+        # there were no local changes fetchers or none had changes.
+        if not self._localChangesEmitted:
+            self.localChangesAvailable.emit(self._lccCommit, self._lucCommit)
+        self._localChangesEmitted = True
 
         for error, _ in self._errors.items():
             self._errorData += error + b'\n'

--- a/qgitc/logsfetcherqprocessworker.py
+++ b/qgitc/logsfetcherqprocessworker.py
@@ -162,7 +162,6 @@ class LogsFetcherQProcessWorker(LogsFetcherWorkerBase):
         self._localChangesTotal = 0
         self._localChangesDone = 0
         self._localChangesEmitted = False
-        self._compositeSubmodules = []
 
         self._quitEventLoopRequested.connect(
             self._quitEventLoop, Qt.QueuedConnection)
@@ -191,7 +190,6 @@ class LogsFetcherQProcessWorker(LogsFetcherWorkerBase):
 
         # Start local-changes fetcher first (fast: git status) so local
         # changes appear before the log fetch (slow: git log) completes.
-        lcFetcher = None
         if self.needLocalChanges():
             lcFetcher = LocalChangesFetcher(self._branchDir, False)
             lcFetcher.finished.connect(self._onFetchFinished)
@@ -300,7 +298,6 @@ class LogsFetcherQProcessWorker(LogsFetcherWorkerBase):
         logsArgs = self._args[1]
         paths = extractFilePaths(logsArgs)
         submodules = filterSubmoduleByPath(self._submodules, paths)
-        self._compositeSubmodules = submodules
 
         self._exitCode = 0
         self._cleanupCompositeEmit()

--- a/qgitc/logsfetcherworkerbase.py
+++ b/qgitc/logsfetcherworkerbase.py
@@ -186,17 +186,23 @@ class LogsFetcherWorkerBase(QObject):
                 subCommit.repoDir = repoDir
                 lccCommit.subCommits.append(subCommit)
 
+        # The subCommit (or lucCommit itself) that owns untrackedFiles for this repoDir.
+        # Untracked files must be associated with their originating repoDir so that
+        # _addUntrackedEntries can set the correct cwd when fetching their diff.
+        untrackedOwner = None
         if hasLUC:
             lucCommit.sha1 = Git.LUC_SHA1
             if not lucCommit.repoDir:
                 lucCommit.repoDir = repoDir
+                untrackedOwner = lucCommit
             else:
                 subCommit = Commit()
                 subCommit.sha1 = Git.LUC_SHA1
                 subCommit.repoDir = repoDir
                 lucCommit.subCommits.append(subCommit)
+                untrackedOwner = subCommit
 
-        if untrackedFiles and lucCommit.isValid():
-            if not lucCommit.untrackedFiles:
-                lucCommit.untrackedFiles = []
-            lucCommit.untrackedFiles.extend(untrackedFiles)
+        if untrackedFiles and untrackedOwner is not None:
+            if not untrackedOwner.untrackedFiles:
+                untrackedOwner.untrackedFiles = []
+            untrackedOwner.untrackedFiles.extend(untrackedFiles)

--- a/qgitc/logview.py
+++ b/qgitc/logview.py
@@ -1757,9 +1757,15 @@ class LogView(QAbstractScrollArea, CommitSource):
             self.__resetGraphs()
             self.viewport().update()
 
-        if self.curIdx == 0 and (hasLUC or hasLCC):
-            # force update the diff
-            self.currentIndexChanged.emit(0)
+        if hasLUC or hasLCC:
+            # If the user's selection was provisional (auto-selected newest row)
+            # or there was no selection yet, move to the local changes row (0)
+            # so the diff updates immediately without waiting for fetchFinished.
+            if self.curIdx == -1 or self.__isSelectionProvisional():
+                self.setCurrentIndex(0)
+            elif self.curIdx == 0:
+                # curIdx is already 0 (local changes replaced the row in-place)
+                self.currentIndexChanged.emit(0)
             self.viewport().update()
 
     def __onFetchTooSlow(self, seconds: int):

--- a/tests/test_logsfetcherworkerbase.py
+++ b/tests/test_logsfetcherworkerbase.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from PySide6.QtTest import QSignalSpy
 
 from qgitc.common import Commit
+from qgitc.gitutils import Git
 from qgitc.logsfetcherworkerbase import LogsFetcherWorkerBase
 from tests.base import TestBase
 
@@ -363,3 +364,58 @@ class TestLogsFetcherWorkerBaseComposite(TestBase):
         self.assertEqual([c2], self._worker._mergedLogs[key].subCommits)
         self.assertIn(c3.sha1, self._worker._mergedLogs,
                       "repoB already contributed, so c3 becomes its own row")
+
+    # ------------------------------------------------------------------
+    #  _makeLocalCommits: untracked files associated with correct repoDir
+    # ------------------------------------------------------------------
+    def testMakeLocalCommits_untrackedFilesOnFirstRepo(self):
+        """Untracked files from the first repo go on the top-level lucCommit."""
+        lcc = Commit()
+        luc = Commit()
+        LogsFetcherWorkerBase._makeLocalCommits(
+            lcc, luc, False, True, ".", ["file1.txt"])
+
+        self.assertEqual(Git.LUC_SHA1, luc.sha1)
+        self.assertEqual(".", luc.repoDir)
+        self.assertEqual(["file1.txt"], luc.untrackedFiles)
+
+    def testMakeLocalCommits_untrackedFilesOnSubCommit(self):
+        """Untracked files from a second repo go on the sub-commit, not the top-level."""
+        lcc = Commit()
+        luc = Commit()
+        # First repo (".") has LUC but no untracked files
+        LogsFetcherWorkerBase._makeLocalCommits(
+            lcc, luc, False, True, ".", None)
+        # Second repo ("sub") has untracked files
+        LogsFetcherWorkerBase._makeLocalCommits(
+            lcc, luc, False, True, "sub", ["sub/file.txt"])
+
+        self.assertEqual(".", luc.repoDir)
+        self.assertEqual([], luc.untrackedFiles,
+                         "top-level should not carry sub's untracked files")
+        self.assertEqual(1, len(luc.subCommits))
+        sub = luc.subCommits[0]
+        self.assertEqual("sub", sub.repoDir)
+        self.assertEqual(["sub/file.txt"], sub.untrackedFiles)
+
+    def testMakeLocalCommits_untrackedFilesMultipleRepos(self):
+        """Untracked files from multiple repos are kept on their respective owners."""
+        lcc = Commit()
+        luc = Commit()
+        LogsFetcherWorkerBase._makeLocalCommits(
+            lcc, luc, False, True, ".", ["top.txt"])
+        LogsFetcherWorkerBase._makeLocalCommits(
+            lcc, luc, False, True, "subA", ["subA/a.txt"])
+        LogsFetcherWorkerBase._makeLocalCommits(
+            lcc, luc, False, True, "subB", ["subB/b.txt"])
+
+        self.assertEqual(["top.txt"], luc.untrackedFiles)
+        self.assertEqual(2, len(luc.subCommits))
+
+        subA = luc.subCommits[0]
+        self.assertEqual("subA", subA.repoDir)
+        self.assertEqual(["subA/a.txt"], subA.untrackedFiles)
+
+        subB = luc.subCommits[1]
+        self.assertEqual("subB", subB.repoDir)
+        self.assertEqual(["subB/b.txt"], subB.untrackedFiles)


### PR DESCRIPTION
## Summary

Fix untracked files handling in composite mode and improve local changes display performance.

## Changes

### fix: associate untracked files with correct repoDir in composite mode
- Store untracked files on their owning sub-commit instead of the top-level lucCommit
- Reset fetcher.repoDir to None when switching to top-level repo
- Fix "Could not access" errors and wrong file paths for untracked files

### feat(diffview): sort untracked files by name in composite mode
- Collect all diff blocks into a dict keyed by file name
- Flush in sorted order so tracked and untracked files are interleaved alphabetically

### perf: fetch local changes before logs for faster initial display
- Start LocalChangesFetchers (git status, fast) before LogsFetcherImpl (git log, slow)
- Emit localChangesAvailable as soon as all LocalChangesFetchers complete
- Immediately refresh diff when local changes arrive, without waiting for fetchFinished

### fix: address review issues
- Guard against KeyError in __onDiffAvailable
- Remove unused variables