### PR TITLE
Fix composite-mode memory leak, thread deadlocks and crashes; add diff file sorting option

### DIFF
--- a/qgitc/data/translations/zh_CN.ts
+++ b/qgitc/data/translations/zh_CN.ts
@@ -3497,6 +3497,11 @@ Please checkout the branch first.</source>
         <translation>显示父子记录</translation>
     </message>
     <message>
+        <location filename="../../preferences.ui" line="306"/>
+        <source>Sort files by name</source>
+        <translation>按文件名排序</translation>
+    </message>
+    <message>
         <location filename="../../preferences.ui" line="477"/>
         <source>Composite Mode</source>
         <translation>聚合模式</translation>

--- a/qgitc/diffview.py
+++ b/qgitc/diffview.py
@@ -192,6 +192,14 @@ class DiffView(QWidget):
         # Diff blocks keyed by file name, collected during fetch and flushed
         # in sorted order when all fetches complete.
         self._pendingDiffs: dict = {}
+        # Per-file split state persisting across incremental parse() chunks:
+        # QProcess delivers stdout in several readyRead chunks, so a single
+        # file's diff commonly spans multiple __onDiffAvailable calls, and
+        # continuation chunks carry no DiffType.File marker for the file they
+        # belong to.
+        self._splitFile: str = None
+        self._splitInfo: FileInfo = None
+        self._splitLines: list = []
 
         self._commitSource: CommitSource = None
         self._showingCommit = False
@@ -564,33 +572,40 @@ class DiffView(QWidget):
         self.twMenu.exec(self.fileListView.mapToGlobal(pos))
 
     def __onDiffAvailable(self, lineItems, fileItems):
-        # Split the block into per-file chunks keyed by file name.
-        # Each chunk starts at a DiffType.File marker and includes all lines
-        # until the next File marker. A leading DiffType.Diff separator line
-        # before the first file is discarded.
-        currentFile = None
-        currentLines = []
+        # Accumulate per-file chunks. A single file's diff may span several
+        # parse() calls (QProcess delivers output in chunks); continuation
+        # chunks contain no DiffType.File marker, so the split state must
+        # persist across calls.
         for diffType, data in lineItems:
             if diffType == DiffType.File:
-                # Flush previous file chunk
-                if currentFile is not None and currentFile in fileItems:
-                    self._pendingDiffs[currentFile] = (currentLines, fileItems[currentFile])
-                # Decode file name from the line data
+                self._flushSplitFile()
                 if isinstance(data, bytes):
-                    currentFile = data.decode("utf-8", errors="replace")
+                    self._splitFile = data.decode("utf-8", errors="replace")
                 else:
-                    currentFile = data
-                currentLines = [(diffType, data)]
-            else:
-                if currentFile is not None:
-                    currentLines.append((diffType, data))
-                # else: skip leading separator lines before first file
+                    self._splitFile = data
+                # The FileInfo is created in the same parse() call as the
+                # marker, so it is in this chunk's fileItems.
+                self._splitInfo = fileItems.get(self._splitFile)
+                self._splitLines = [(diffType, data)]
+            elif self._splitFile is not None:
+                self._splitLines.append((diffType, data))
+            # else: skip leading separator lines before the first file marker
 
-        # Flush last file chunk
-        if currentFile is not None and currentFile in fileItems:
-            self._pendingDiffs[currentFile] = (currentLines, fileItems[currentFile])
+    def _flushSplitFile(self):
+        """Move the accumulated split state into _pendingDiffs."""
+        if self._splitFile is not None and self._splitInfo is not None:
+            self._pendingDiffs[self._splitFile] = (
+                self._splitLines, self._splitInfo)
+        self._splitFile = None
+        self._splitInfo = None
+        self._splitLines = []
 
     def __onDiffFileStateChanged(self, filePath: str, newState: FileState):
+        # The file is not in the file list until _flushPendingDiffs, so also
+        # apply the state to the pending FileInfo (state lines arrive right
+        # after the marker, i.e. while the file is still being split).
+        if filePath == self._splitFile and self._splitInfo is not None:
+            self._splitInfo.state = newState
         self.fileListModel.updateFileState(filePath, newState)
 
     def __onFetchFinished(self, exitCode):
@@ -624,6 +639,8 @@ class DiffView(QWidget):
 
     def _flushPendingDiffs(self):
         """Flush pending diff blocks sorted by file name to viewer + file list."""
+        # The last file's diff has no following marker; flush it too.
+        self._flushSplitFile()
         diffs = self._pendingDiffs
         self._pendingDiffs = {}
         if not diffs:
@@ -830,6 +847,9 @@ class DiffView(QWidget):
         self.fileListModel.clear()
         self.viewer.clear()
         self._pendingDiffs.clear()
+        self._splitFile = None
+        self._splitInfo = None
+        self._splitLines = []
         self._updateFilterStatus()
         self.commit = None
         self._delayCommit = None

--- a/qgitc/diffview.py
+++ b/qgitc/diffview.py
@@ -638,7 +638,11 @@ class DiffView(QWidget):
                                  self.fetcher.errorData.decode("utf-8"))
 
     def _flushPendingDiffs(self):
-        """Flush pending diff blocks sorted by file name to viewer + file list."""
+        """Flush pending diff blocks to viewer + file list.
+
+        Sorted by file name when the user enabled it; otherwise the original
+        git output order (dict insertion order) is kept.
+        """
         # The last file's diff has no following marker; flush it too.
         self._flushSplitFile()
         diffs = self._pendingDiffs
@@ -646,8 +650,13 @@ class DiffView(QWidget):
         if not diffs:
             return
 
+        if ApplicationBase.instance().settings().sortDiffByFile():
+            names = sorted(diffs, key=str.lower)
+        else:
+            names = list(diffs)
+
         row = self.viewer.textLineCount()
-        for fileName in sorted(diffs, key=str.lower):
+        for fileName in names:
             lineItems, info = diffs[fileName]
             info.row = row
             self.fileListModel.addFile(fileName, info)

--- a/qgitc/findsubmodules.py
+++ b/qgitc/findsubmodules.py
@@ -3,6 +3,7 @@
 import os
 
 from PySide6.QtCore import QEventLoop, QProcess, QThread
+from shiboken6 import Shiboken
 
 from qgitc.common import logger
 from qgitc.gitutils import Git, GitProcess
@@ -73,9 +74,27 @@ class FindSubmoduleThread(QThread):
         process = QProcess()
         process.setWorkingDirectory(self._repoDir)
         process.finished.connect(self._eventLoop.quit)
+        # A failed start emits errorOccurred and never finished; without
+        # quitting on it the wait below would block until interrupted and
+        # submodules would never be discovered (e.g. broken git binary).
+        process.errorOccurred.connect(self._eventLoop.quit)
         args = ["submodule", "foreach", "--quiet", "echo $name"]
         process.start(GitProcess.GIT_BIN, args)
-        self._eventLoop.exec()
+        if process.state() != QProcess.ProcessState.NotRunning:
+            # On Windows a failed start is reported synchronously from
+            # start() (errorOccurred above), so only wait when it actually
+            # started; a quit delivered before exec() may be lost.
+            self._eventLoop.exec()
+        # Drop the loop here so it is destroyed in this (worker) thread;
+        # keeping it as an instance attribute would destroy it later from
+        # the GUI thread or at interpreter teardown — cross-thread QObject
+        # destruction.
+        self._eventLoop = None
+
+        if not Shiboken.isValid(process):
+            # The interpreter is tearing down and already destroyed the
+            # underlying C++ object; bail out without touching it.
+            return
 
         if self.isInterruptionRequested():
             if process.state() == QProcess.ProcessState.Running:

--- a/qgitc/gitutils.py
+++ b/qgitc/gitutils.py
@@ -86,7 +86,13 @@ class QGitProcess():
             if QCoreApplication.instance() is None or QCoreApplication.instance().thread() != QThread.currentThread():
                 self._process.waitForFinished()
             else:
-                while not self._process.waitForFinished(50):
+                # Loop on the state, not on waitForFinished()'s return value:
+                # if the child exits while processEvents() runs, the state
+                # becomes NotRunning and waitForFinished() then returns False
+                # ("process is not running") forever, spinning the GUI thread.
+                while self._process.state() == QProcess.Running:
+                    if self._process.waitForFinished(50):
+                        break
                     if self._cancelled:
                         return None, None
                     QCoreApplication.instance().processEvents()

--- a/qgitc/logsfetcher.py
+++ b/qgitc/logsfetcher.py
@@ -64,29 +64,28 @@ class LogsFetcher(QObject):
             self._worker.localChangesAvailable.disconnect(
                 self._onLocalChangesAvailable)
             self._worker.requestInterruption()
-            # Defer _worker cleanup to _onThreadFinished to avoid
-            # QBasicTimer cross-thread warnings, but clear the
-            # attribute now so fetch() knows a new worker is needed.
-            # _pendingWorkers keeps the ref alive until the thread stops.
             self._worker = None
 
-        if self._thread and self._thread.isRunning():
-            self._thread.quit()
-
-            if force and ApplicationBase.instance().terminateThread(self._thread):
-                self._threads.remove(self._thread)
-                self._thread.finished.disconnect(self._onThreadFinished)
-                worker = self._pendingWorkers.pop(self._thread, None)
-                if worker:
-                    worker.deleteLater()
-                logger.warning("Terminating logs fetcher thread")
-                self._thread = None
+        if self._thread:
+            if self._thread.isRunning():
+                self._thread.quit()
+                if force and ApplicationBase.instance().terminateThread(self._thread):
+                    self._threads.remove(self._thread)
+                    worker = self._pendingWorkers.pop(self._thread, None)
+                    if worker:
+                        worker.deleteLater()
+                    logger.warning("Terminating logs fetcher thread")
+            # If thread is not running, _onThreadFinished should have
+            # already cleaned up _threads and _pendingWorkers.
+            self._thread = None
 
         if not force:
             return
 
         for thread in self._threads:
-            thread.finished.disconnect(self._onThreadFinished)
+            worker = self._pendingWorkers.pop(thread, None)
+            if worker:
+                worker.deleteLater()
             ApplicationBase.instance().terminateThread(thread)
         self._threads.clear()
 

--- a/qgitc/logsfetcher.py
+++ b/qgitc/logsfetcher.py
@@ -35,6 +35,8 @@ class LogsFetcher(QObject):
     def fetch(self, *args, branchDir=None):
         self.cancel()
         self._errorData = b''
+        logger.debug("LogsFetcher.fetch: threads=%d pending=%d",
+                     len(self._threads), len(self._pendingWorkers))
         # always detect local changes for single repo
         noLocalChanges = len(self._submodules) > 0 and not ApplicationBase.instance(
         ).settings().detectLocalChanges()
@@ -135,6 +137,8 @@ class LogsFetcher(QObject):
 
     def _onThreadFinished(self):
         thread = self.sender()
+        logger.debug("_onThreadFinished: thread=%s in_threads=%s pending=%d",
+                     thread, thread in self._threads, len(self._pendingWorkers))
         if thread in self._threads:
             self._threads.remove(thread)
         # Clean up the worker now that its thread has fully stopped.

--- a/qgitc/logsfetcher.py
+++ b/qgitc/logsfetcher.py
@@ -149,6 +149,12 @@ class LogsFetcher(QObject):
             # and waits for the Python GIL, while the GUI thread holds the
             # GIL and waits for those Qt locks.
             worker.releaseFinishedFetchers()
+            # The thread has fully stopped, so dropping the worker's
+            # retained data cannot race with it. This is the safety net for
+            # paths that skip the end-of-fetch release (e.g. a run() that
+            # raised); without it a lingering worker wrapper would retain
+            # the whole commit set.
+            worker.releaseData()
             worker.deleteLater()
         if thread is self._thread:
             self._worker = None

--- a/qgitc/logsfetcher.py
+++ b/qgitc/logsfetcher.py
@@ -35,8 +35,6 @@ class LogsFetcher(QObject):
     def fetch(self, *args, branchDir=None):
         self.cancel()
         self._errorData = b''
-        logger.debug("LogsFetcher.fetch: threads=%d pending=%d",
-                     len(self._threads), len(self._pendingWorkers))
         # always detect local changes for single repo
         noLocalChanges = len(self._submodules) > 0 and not ApplicationBase.instance(
         ).settings().detectLocalChanges()
@@ -75,6 +73,7 @@ class LogsFetcher(QObject):
                     self._threads.remove(self._thread)
                     worker = self._pendingWorkers.pop(self._thread, None)
                     if worker:
+                        worker.releaseFinishedFetchers()
                         worker.deleteLater()
                     logger.warning("Terminating logs fetcher thread")
             # If thread is not running, _onThreadFinished should have
@@ -87,6 +86,7 @@ class LogsFetcher(QObject):
         for thread in self._threads:
             worker = self._pendingWorkers.pop(thread, None)
             if worker:
+                worker.releaseFinishedFetchers()
                 worker.deleteLater()
             ApplicationBase.instance().terminateThread(thread)
         self._threads.clear()
@@ -137,8 +137,6 @@ class LogsFetcher(QObject):
 
     def _onThreadFinished(self):
         thread = self.sender()
-        logger.debug("_onThreadFinished: thread=%s in_threads=%s pending=%d",
-                     thread, thread in self._threads, len(self._pendingWorkers))
         if thread in self._threads:
             self._threads.remove(thread)
         # Clean up the worker now that its thread has fully stopped.
@@ -146,6 +144,11 @@ class LogsFetcher(QObject):
         # (with internal QBasicTimer) while the thread is still running.
         worker = self._pendingWorkers.pop(thread, None)
         if worker:
+            # Destroy the fetchers in the GUI thread. Destroying QObjects in
+            # the worker thread deadlocks: the worker holds Qt object locks
+            # and waits for the Python GIL, while the GUI thread holds the
+            # GIL and waits for those Qt locks.
+            worker.releaseFinishedFetchers()
             worker.deleteLater()
         if thread is self._thread:
             self._worker = None

--- a/qgitc/logsfetcherqprocessworker.py
+++ b/qgitc/logsfetcherqprocessworker.py
@@ -175,7 +175,13 @@ class LogsFetcherQProcessWorker(LogsFetcherWorkerBase):
     def _onFetchNormalLogsFinished(self):
         fetcher = self.sender()
         self._fetchers.remove(fetcher)
-        fetcher.deleteLater()
+        # Do NOT call fetcher.deleteLater() here: the DeferredDelete would be
+        # processed by this thread's event loop with the GIL released, and
+        # destroying the QObject acquires Qt locks while Shiboken waits for
+        # the GIL — deadlocking against the GUI thread which holds the GIL
+        # while waiting for those Qt locks. The fetcher stays alive in
+        # _finishedFetchers and is released in the GUI thread by
+        # releaseFinishedFetchers().
         self._finishedFetchers.append(fetcher)
         if not self._fetchers and self._eventLoop:
             self._eventLoop.quit()
@@ -226,7 +232,6 @@ class LogsFetcherQProcessWorker(LogsFetcherWorkerBase):
             self._errorData.rstrip(b'\n')
 
         self.fetchFinished.emit(fetcher._exitCode)
-        self._finishedFetchers.clear()
 
     def _onFetchLogsFinished(self, fetcher: LogsFetcherImpl):
         repoDir = fetcher.repoDir
@@ -269,7 +274,8 @@ class LogsFetcherQProcessWorker(LogsFetcherWorkerBase):
 
         fetcher = self.sender()
         self._fetchers.remove(fetcher)
-        fetcher.deleteLater()
+        # Do NOT deleteLater() here — see the comment in
+        # _onFetchNormalLogsFinished. Released in the GUI thread instead.
         self._finishedFetchers.append(fetcher)
 
         if self._queueTasks:
@@ -380,7 +386,6 @@ class LogsFetcherQProcessWorker(LogsFetcherWorkerBase):
 
         self._eventLoop = None
         self.fetchFinished.emit(self._exitCode)
-        self._finishedFetchers.clear()
 
     def requestInterruption(self):
         self._interruptionRequested = True
@@ -399,9 +404,27 @@ class LogsFetcherQProcessWorker(LogsFetcherWorkerBase):
             self._eventLoop.quit()
 
     def _clearFetcher(self):
-        self._queueTasks.clear()
         for fetcher in self._fetchers:
             fetcher.cancel()
+        # Keep every fetcher alive: destroying QObjects in this worker thread
+        # can deadlock against the GUI thread (this thread would hold the
+        # Python GIL while acquiring Qt object locks that the GUI thread may
+        # hold while waiting for the GIL). They are released in the GUI
+        # thread by releaseFinishedFetchers() once this thread has stopped.
+        self._finishedFetchers.extend(self._fetchers)
         self._fetchers.clear()
-        self._finishedFetchers.clear()
+        self._finishedFetchers.extend(self._queueTasks)
+        self._queueTasks.clear()
         self._cleanupCompositeEmit()
+
+    def releaseFinishedFetchers(self):
+        """Drop references to all fetchers so they are destroyed.
+
+        Must be called from the GUI thread after the worker thread has
+        stopped. Destroying the fetchers (and their QProcess children) in
+        the worker thread deadlocks: the worker would hold the Python GIL
+        while acquiring Qt object locks that the GUI thread may hold while
+        waiting for the GIL (e.g. inside QMetaObject::activate delivering a
+        signal to a Python slot).
+        """
+        self._finishedFetchers.clear()

--- a/qgitc/logsfetcherqprocessworker.py
+++ b/qgitc/logsfetcherqprocessworker.py
@@ -232,6 +232,10 @@ class LogsFetcherQProcessWorker(LogsFetcherWorkerBase):
             self._errorData.rstrip(b'\n')
 
         self.fetchFinished.emit(fetcher._exitCode)
+        # The local-change commits were emitted and are owned by the
+        # consumer now; drop our references.
+        self._lccCommit = Commit()
+        self._lucCommit = Commit()
 
     def _onFetchLogsFinished(self, fetcher: LogsFetcherImpl):
         repoDir = fetcher.repoDir
@@ -386,6 +390,22 @@ class LogsFetcherQProcessWorker(LogsFetcherWorkerBase):
 
         self._eventLoop = None
         self.fetchFinished.emit(self._exitCode)
+        # All data-carrying signals have been queued and are owned by their
+        # receivers now; drop our copy so a lingering worker wrapper does
+        # not retain the whole commit set (see _releaseCompositeData).
+        self._releaseCompositeData()
+        self._lccCommit = Commit()
+        self._lucCommit = Commit()
+
+    def releaseData(self):
+        """Release fetch data retained by this worker (see base class).
+
+        Also drops the local-change commits: they were emitted to the
+        consumer, which keeps its own references.
+        """
+        super().releaseData()
+        self._lccCommit = Commit()
+        self._lucCommit = Commit()
 
     def requestInterruption(self):
         self._interruptionRequested = True

--- a/qgitc/logsfetcherworkerbase.py
+++ b/qgitc/logsfetcherworkerbase.py
@@ -83,9 +83,10 @@ class LogsFetcherWorkerBase(QObject):
             handleCount += 1
             if handleCount % 100 == 0 and self.isInterruptionRequested():
                 return
-            # Future-dated commits (e.g. clock skew, 2050) are set aside
-            # and appended to the end of the list later.
-            if log.committerDateTime.timestamp() > now:
+            # Commits with no date or future dates (e.g. clock skew, 2050)
+            # are set aside and appended to the end of the list later.
+            dt = log.committerDateTime
+            if dt is None or dt.timestamp() > now:
                 self._futureLogs.append(log)
                 continue
             # require same day at least
@@ -164,7 +165,10 @@ class LogsFetcherWorkerBase(QObject):
         newCount = len(batch)
         runStart = i
         while i < oldCount and j < newCount:
-            if batch[j].committerDateTime > old[i].committerDateTime:
+            # Treat None committerDateTime as oldest (sorts to end)
+            batchDt = batch[j].committerDateTime
+            oldDt = old[i].committerDateTime
+            if batchDt is not None and (oldDt is None or batchDt > oldDt):
                 if i > runStart:
                     merged.extend(old[runStart:i])
                 insertPositions.append(i)

--- a/qgitc/logsfetcherworkerbase.py
+++ b/qgitc/logsfetcherworkerbase.py
@@ -239,6 +239,32 @@ class LogsFetcherWorkerBase(QObject):
         self._allLogs.clear()
         self._futureLogs.clear()
 
+    def _releaseCompositeData(self):
+        """Drop the accumulated composite data after the fetch completes.
+
+        Rebind instead of clearing in place: the last emitted batch is
+        owned by the queued signal payload (and the view's data list), so
+        those objects survive there. Without this, a finished worker
+        retains the full commit set — hundreds of thousands of Commit
+        objects on large composite repos — until the worker itself is
+        destroyed, which may never happen because its DeferredDelete is
+        queued to a thread that no longer runs an event loop.
+        """
+        self._mergedLogs = {}
+        self._mergedRepoDirs = {}
+        self._newLogs = []
+        self._allLogs = []
+        self._futureLogs = []
+
+    def releaseData(self):
+        """Release fetch data retained by this worker.
+
+        Only call after the worker thread has stopped (e.g. from the GUI
+        thread's thread-finished handler): rebinding these containers
+        while the worker is still merging would race with it.
+        """
+        self._releaseCompositeData()
+
     @property
     def errorData(self):
         return self._errorData

--- a/qgitc/logview.py
+++ b/qgitc/logview.py
@@ -1519,10 +1519,12 @@ class LogView(QAbstractScrollArea, CommitSource):
             while pinned < len(self.data) and \
                     self.data[pinned].committerDateTime is None:
                 pinned += 1
-            if pinned > 0:
-                self.data = self.data[:pinned] + allLogs
-            else:
-                self.data = allLogs
+            # Always build a NEW list; never alias the worker's _allLogs.
+            # This view mutates self.data in place (local-change rows in
+            # __onLocalChangesAvailable, clear()), and the worker mutates and
+            # reads _allLogs concurrently (merge, _cleanupCompositeEmit) —
+            # aliasing would let either side corrupt the other's list.
+            self.data = self.data[:pinned] + allLogs
 
             # insertPositions are indices into allLogs (without pinned);
             # shift by pinned to match self.data which has pinned prepended

--- a/qgitc/logview.py
+++ b/qgitc/logview.py
@@ -678,9 +678,15 @@ class LogView(QAbstractScrollArea, CommitSource):
         app.settings().logViewFontChanged.connect(self.updateSettings)
         app.settings().compositeModeChanged.connect(self.__onCompositeModeChanged)
 
-        logWindow = self.logWindow()
-        if logWindow:
-            app.submoduleAvailable.connect(self.__onSubmoduleAvailable)
+        # Do NOT gate this on logWindow(): during the LogWindow's own
+        # construction (which creates this view) getWindow(LogWindow, False)
+        # still returns None, so the connection would never be made for the
+        # main log view — a finished submodule scan could not reload it into
+        # composite mode on first open of a repo. Connect unconditionally
+        # instead: __onCompositeModeChanged already no-ops for non-standalone
+        # views (commit panel, blame view), same as compositeModeChanged
+        # above.
+        app.submoduleAvailable.connect(self.__onSubmoduleAvailable)
 
         self._finder.resultAvailable.connect(
             self.__onFindResultAvailable)

--- a/qgitc/preferences.py
+++ b/qgitc/preferences.py
@@ -379,6 +379,7 @@ class Preferences(QDialog):
         self.ui.cbIgnoreWhitespace.setCurrentIndex(index)
 
         self.ui.cbShowPC.setChecked(self.settings.showParentChild())
+        self.ui.cbSortDiffByFile.setChecked(self.settings.sortDiffByFile())
 
     def _saveGeneralTab(self):
         value = self.ui.cbEsc.isChecked()
@@ -423,6 +424,9 @@ class Preferences(QDialog):
 
         value = self.ui.cbShowPC.isChecked()
         self.settings.setShowParentChild(value)
+
+        value = self.ui.cbSortDiffByFile.isChecked()
+        self.settings.setSortDiffByFile(value)
 
     def _initFontsTab(self):
         font = self.settings.logViewFont()

--- a/qgitc/preferences.ui
+++ b/qgitc/preferences.ui
@@ -303,6 +303,13 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="cbSortDiffByFile">
+            <property name="text">
+             <string>Sort files by name</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/qgitc/settings.py
+++ b/qgitc/settings.py
@@ -524,6 +524,12 @@ class Settings(QSettings):
     def setShowParentChild(self, show):
         self.setValue("showParentChild", show)
 
+    def sortDiffByFile(self):
+        return self.value("sortDiffByFile", False, type=bool)
+
+    def setSortDiffByFile(self, sort):
+        self.setValue("sortDiffByFile", sort)
+
     def colorSchemaMode(self):
         return self.value("colorSchemaMode", 0, type=int)
 

--- a/qgitc/submoduleexecutor.py
+++ b/qgitc/submoduleexecutor.py
@@ -157,26 +157,55 @@ class SubmoduleExecutor(QObject):
         self._threads.append(self._thread)
         self._thread.start()
 
+    @staticmethod
+    def _disconnectQuietly(signal, slot):
+        """Disconnect `signal` from `slot`, tolerating an absent connection.
+
+        cancel() can process the same thread twice: _terminateThread()
+        pumps the GUI event loop while waiting for the thread, which
+        delivers queued finished() handlers re-entrantly, and
+        StatusFetcher.onFinished() re-submits on top. That can disconnect
+        a thread underneath a later cancel() pass. PySide6 raises
+        RuntimeError when disconnecting a connection that is already
+        gone, so the disconnects here must be idempotent.
+        """
+        try:
+            signal.disconnect(slot)
+        except RuntimeError:
+            pass
+
     def cancel(self, force=False):
-        if self._thread and self._thread.isRunning():
+        thread = self._thread
+        # Detach first: the terminate wait below pumps the event loop and
+        # queued finished() handlers run re-entrantly; they must not see a
+        # stale current thread (this also clears the reference when the
+        # thread already finished but its handlers are still pending).
+        self._thread = None
+
+        if thread and thread.isRunning():
             logger.info("cancelling submodule thread")
-            self._thread.finished.disconnect(self.onFinished)
-            self._thread.started.disconnect(self.started)
-            self._thread.requestInterruption()
+            self._disconnectQuietly(thread.finished, self.onFinished)
+            self._disconnectQuietly(thread.started, self.started)
+            thread.requestInterruption()
 
             if force:
-                self._threads.remove(self._thread)
-                self._thread.finished.disconnect(self._onThreadFinished)
-                self._terminateThread(self._thread)
-            self._thread = None
+                if thread in self._threads:
+                    self._threads.remove(thread)
+                self._disconnectQuietly(
+                    thread.finished, self._onThreadFinished)
+                self._terminateThread(thread)
 
         if not force:
             return
 
-        for thread in self._threads:
-            thread.finished.disconnect(self._onThreadFinished)
+        # Snapshot and clear before iterating: a re-entrant submit during
+        # the terminate waits below appends to the fresh list instead of
+        # being disconnected and cleared by this same pass.
+        threads = self._threads
+        self._threads = []
+        for thread in threads:
+            self._disconnectQuietly(thread.finished, self._onThreadFinished)
             self._terminateThread(thread)
-        self._threads.clear()
 
     def isRunning(self):
         return self._thread is not None and self._thread.isRunning()

--- a/tests/test_diffview.py
+++ b/tests/test_diffview.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for DiffView's incremental per-file diff accumulation."""
+
+from qgitc.diffutils import DiffType, FileInfo, FileState
+from qgitc.diffview import DiffView
+from tests.base import TestBase
+
+
+class TestDiffViewChunkedDiff(TestBase):
+    """A file's diff spans several parse() chunks (QProcess delivers stdout
+    in multiple readyRead chunks); the view must accumulate it across
+    __onDiffAvailable calls instead of dropping continuation lines."""
+
+    def doCreateRepo(self):
+        """No repo needed for these unit-level tests."""
+        pass
+
+    def setUp(self):
+        super().setUp()
+        self._view = DiffView()
+
+    def tearDown(self):
+        self._view.deleteLater()
+        self.processEvents()
+        super().tearDown()
+
+    def _emitChunk(self, lineItems, fileItems):
+        self._view._DiffView__onDiffAvailable(lineItems, fileItems)
+
+    def testFileDiffSpanningChunks(self):
+        """Continuation chunks (no DiffType.File marker) must not be dropped."""
+        # Chunk 1: the file marker, its info line and the first hunk lines.
+        self._emitChunk(
+            [(DiffType.File, b"include/shell/et.h"),
+             (DiffType.FileInfo, b"index 9122d00ef..da719d5f5 100644"),
+             (DiffType.Diff, b"@@ -2122,6 +2122,39 @@ struct ShellEtFindOptions"),
+             (DiffType.Diff, b"+struct ShellEtFindResult")],
+            {"include/shell/et.h": FileInfo(3)})
+
+        # Chunk 2: continuation of the same file's diff — no file marker.
+        self._emitChunk(
+            [(DiffType.Diff, b"+{"),
+             (DiffType.Diff, b"+       std::u16string searchText;"),
+             (DiffType.Diff, b"+};")],
+            {})
+
+        self._view._flushSplitFile()
+
+        self.assertIn("include/shell/et.h", self._view._pendingDiffs)
+        lineItems, _ = self._view._pendingDiffs["include/shell/et.h"]
+        # marker + info + hunk header + 4 content lines = 7
+        self.assertEqual(7, len(lineItems),
+                         "all lines from both chunks must be kept")
+
+    def testNextFileMarkerFlushesPrevious(self):
+        """A new file marker must flush the accumulated previous file."""
+        self._emitChunk(
+            [(DiffType.File, b"a.txt"),
+             (DiffType.Diff, b"+first")],
+            {"a.txt": FileInfo(1)})
+
+        self._emitChunk(
+            [(DiffType.Diff, b"+second"),
+             (DiffType.File, b"b.txt"),
+             (DiffType.Diff, b"+other")],
+            {"b.txt": FileInfo(3)})
+
+        self.assertIn("a.txt", self._view._pendingDiffs)
+        lineItems, _ = self._view._pendingDiffs["a.txt"]
+        self.assertEqual(3, len(lineItems),
+                         "a.txt must carry its marker line and both diff lines")
+        self.assertEqual([b"+first", b"+second"],
+                         [d for t, d in lineItems if t == DiffType.Diff])
+
+        # b.txt is still being split (no following marker yet)
+        self.assertNotIn("b.txt", self._view._pendingDiffs)
+        self.assertEqual("b.txt", self._view._splitFile)
+
+    def testStateUpdateAppliedToPendingFile(self):
+        """fileStateChanged for the file being split must update its
+        pending FileInfo (the file is not in the list until the flush)."""
+        info = FileInfo(1)
+        self._emitChunk(
+            [(DiffType.File, b"new.txt"),
+             (DiffType.Diff, b"+content")],
+            {"new.txt": info})
+
+        self._view._DiffView__onDiffFileStateChanged("new.txt", FileState.Added)
+
+        self.assertEqual(FileState.Added, info.state)
+
+    def testClearResetsSplitState(self):
+        self._emitChunk(
+            [(DiffType.File, b"a.txt"),
+             (DiffType.Diff, b"+x")],
+            {"a.txt": FileInfo(1)})
+
+        self._view.clear()
+
+        self.assertIsNone(self._view._splitFile)
+        self.assertIsNone(self._view._splitInfo)
+        self.assertEqual([], self._view._splitLines)
+        self.assertEqual({}, self._view._pendingDiffs)

--- a/tests/test_diffview.py
+++ b/tests/test_diffview.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Unit tests for DiffView's incremental per-file diff accumulation."""
 
+from qgitc.applicationbase import ApplicationBase
 from qgitc.diffutils import DiffType, FileInfo, FileState
 from qgitc.diffview import DiffView
 from tests.base import TestBase
@@ -101,3 +102,51 @@ class TestDiffViewChunkedDiff(TestBase):
         self.assertIsNone(self._view._splitInfo)
         self.assertEqual([], self._view._splitLines)
         self.assertEqual({}, self._view._pendingDiffs)
+
+
+class TestDiffViewFileOrder(TestBase):
+    """File order in the diff view follows the sortDiffByFile setting."""
+
+    def doCreateRepo(self):
+        """No repo needed for these unit-level tests."""
+        pass
+
+    def setUp(self):
+        super().setUp()
+        self._view = DiffView()
+
+    def tearDown(self):
+        self._view.deleteLater()
+        self.processEvents()
+        super().tearDown()
+
+    def _addFiles(self, *names):
+        """Accumulate one file per name, in the given (git output) order."""
+        for i, name in enumerate(names):
+            self._view._DiffView__onDiffAvailable(
+                [(DiffType.File, name.encode()),
+                 (DiffType.Diff, b"+content")],
+                {name: FileInfo(i)})
+
+    def _flushedFileOrder(self):
+        self._view._flushPendingDiffs()
+        return [f for f, _ in self._view.fileListModel._fileList]
+
+    def testDefaultIsUnsorted(self):
+        """The setting defaults to off: keep the git output order."""
+        settings = ApplicationBase.instance().settings()
+        self.assertFalse(settings.sortDiffByFile())
+
+        self._addFiles("zebra.txt", "alpha.txt", "mid.txt")
+        self.assertEqual(["zebra.txt", "alpha.txt", "mid.txt"],
+                         self._flushedFileOrder())
+
+    def testSortedWhenEnabled(self):
+        settings = ApplicationBase.instance().settings()
+        settings.setSortDiffByFile(True)
+        try:
+            self._addFiles("zebra.txt", "alpha.txt", "mid.txt")
+            self.assertEqual(["alpha.txt", "mid.txt", "zebra.txt"],
+                             self._flushedFileOrder())
+        finally:
+            settings.setSortDiffByFile(False)

--- a/tests/test_findsubmodules.py
+++ b/tests/test_findsubmodules.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from qgitc.findsubmodules import FindSubmoduleThread
+from qgitc.gitutils import GitProcess
+from tests.base import TestBase
+
+
+class TestFindSubmoduleThread(TestBase):
+
+    def createSubRepo(self):
+        return True
+
+    def testStartFailureFallsBackToFileWalk(self):
+        """A failed process start must not hang the thread forever.
+
+        QProcess emits errorOccurred (never finished) when the program
+        cannot be started; without quitting the wait on it, the thread
+        blocks until interrupted and submodules are never discovered
+        (e.g. broken git binary).
+        """
+        oldBin = GitProcess.GIT_BIN
+        GitProcess.GIT_BIN = "definitely-not-a-git-binary.exe"
+        try:
+            thread = FindSubmoduleThread(self.gitDir.name)
+            thread.start()
+            self.wait(5000, thread.isRunning)
+        finally:
+            GitProcess.GIT_BIN = oldBin
+
+        self.assertFalse(thread.isRunning())
+        self.assertIn("subRepo", thread.submodules)
+
+    def testEventLoopNotRetainedAfterRun(self):
+        """run() must not leave the QEventLoop referenced after it returns.
+
+        The loop is created in the worker thread; keeping it as an instance
+        attribute would destroy it later from the GUI thread (or at
+        interpreter teardown) — cross-thread QObject destruction.
+        """
+        thread = FindSubmoduleThread(self.gitDir.name)
+        thread.start()
+        self.wait(5000, thread.isRunning)
+
+        self.assertFalse(thread.isRunning())
+        self.assertIsNone(thread._eventLoop)
+        self.assertTrue(thread.submodules)

--- a/tests/test_logsfetcherqprocessworker.py
+++ b/tests/test_logsfetcherqprocessworker.py
@@ -140,6 +140,69 @@ class TestLogsFetcherQProcessWorker(TestBase):
         self.assertEqual(lucCommit.sha1, Git.LUC_SHA1)
         self.assertIn("untracked.py", lucCommit.untrackedFiles)
 
+    def testCompositeDataReleasedAfterFetch(self):
+        """A completed composite fetch must not retain the dataset.
+
+        The worker wrapper can outlive the fetch indefinitely (its
+        destruction is deferred to a thread that no longer runs), so
+        retaining _allLogs/_mergedLogs would leak the whole commit set on
+        every reload.
+        """
+        submodules = [".", "subRepo"]
+        worker = LogsFetcherQProcessWorker(
+            submodules, self.gitDir.name, False, "main", None)
+        spyFinished = QSignalSpy(worker.fetchFinished)
+        spyLogsAvailable = QSignalSpy(worker.logsAvailable)
+        spyLocalChangesAvailable = QSignalSpy(worker.localChangesAvailable)
+        worker.run()
+
+        self.wait(100, lambda: spyFinished.count() == 0)
+        self.assertEqual(spyFinished.count(), 1)
+
+        # the emitted payload is owned by the receiver and must survive
+        allLogs, _ = spyLogsAvailable.at(0)[0]
+        self.assertEqual(len(allLogs), 3)
+
+        # ... but the worker itself must not retain the data
+        self.assertEqual(len(worker._allLogs), 0)
+        self.assertEqual(len(worker._mergedLogs), 0)
+        self.assertEqual(len(worker._mergedRepoDirs), 0)
+        self.assertEqual(len(worker._newLogs), 0)
+        self.assertEqual(len(worker._futureLogs), 0)
+
+        # local-change commits were emitted; the worker must drop its refs
+        self.assertEqual(spyLocalChangesAvailable.count(), 1)
+        emittedLcc = spyLocalChangesAvailable.at(0)[0]
+        self.assertIsNot(worker._lccCommit, emittedLcc)
+
+    def testReleaseDataDropsRetainedState(self):
+        """releaseData() drops data retained by a finished worker.
+
+        It is the belt-and-braces cleanup for paths that skip the
+        end-of-fetch release (e.g. a run() that raised). Only valid once
+        the worker thread has stopped; rebinding while the worker is still
+        merging would race with it.
+        """
+        worker = LogsFetcherQProcessWorker(
+            ["."], self.gitDir.name, False, "main", None)
+        worker._allLogs = [Commit(), Commit()]
+        worker._mergedLogs = {"k": Commit()}
+        worker._mergedRepoDirs = {"k": {"."}}
+        worker._newLogs = [Commit()]
+        worker._futureLogs = [Commit()]
+        oldLcc = worker._lccCommit
+        oldLuc = worker._lucCommit
+
+        worker.releaseData()
+
+        self.assertEqual(len(worker._allLogs), 0)
+        self.assertEqual(len(worker._mergedLogs), 0)
+        self.assertEqual(len(worker._mergedRepoDirs), 0)
+        self.assertEqual(len(worker._newLogs), 0)
+        self.assertEqual(len(worker._futureLogs), 0)
+        self.assertIsNot(worker._lccCommit, oldLcc)
+        self.assertIsNot(worker._lucCommit, oldLuc)
+
     def testRequestInterruptionQuitsEventLoopOnWorkerThread(self):
         class StrictEventLoop:
             def __init__(self, ownerThread):

--- a/tests/test_logsfetcherqprocessworker.py
+++ b/tests/test_logsfetcherqprocessworker.py
@@ -203,9 +203,11 @@ class TestLogsFetcherQProcessWorker(TestBase):
 
     def testFinishedFetchersKeptAliveUntilCleanup(self):
         """After _onFetchFinished removes a fetcher, it must be kept alive via
-        _finishedFetchers (with deleteLater) to prevent Python GC from destroying
-        QProcess children (with internal QBasicTimers) on a potentially different
-        thread, which produces:
+        _finishedFetchers (no deleteLater in the worker thread — that
+        deadlocks against the GUI thread) until releaseFinishedFetchers() is
+        called from the GUI thread, preventing Python GC from destroying
+        QProcess children (with internal QBasicTimers) on a potentially
+        different thread, which produces:
           "QBasicTimer::stop: Failed. Possibly trying to stop from a different thread"
         """
         submodules = [".", "subRepo"]
@@ -217,9 +219,13 @@ class TestLogsFetcherQProcessWorker(TestBase):
         self.wait(2000, lambda: spyFinished.count() == 0)
         self.assertEqual(spyFinished.count(), 1)
 
-        # Verify that finished fetchers were tracked and then cleared
+        # Fetchers must stay alive after run() — they are only released by
+        # the GUI thread via releaseFinishedFetchers().
+        self.assertGreater(len(worker._finishedFetchers), 0,
+                           "_finishedFetchers must keep fetchers alive after run()")
+        worker.releaseFinishedFetchers()
         self.assertEqual(len(worker._finishedFetchers), 0,
-                         "_finishedFetchers must be cleared after success")
+                         "_finishedFetchers must be cleared by releaseFinishedFetchers()")
 
         # Verify with gc pressure: create a worker, set low GC threshold,
         # run to completion, and confirm no crash or missing entries
@@ -235,8 +241,11 @@ class TestLogsFetcherQProcessWorker(TestBase):
 
             self.wait(5000, lambda: spyFinished2.count() == 0)
             self.assertEqual(spyFinished2.count(), 1)
+            self.assertGreater(len(worker2._finishedFetchers), 0,
+                               "fetchers must survive GC pressure until released")
+            worker2.releaseFinishedFetchers()
             self.assertEqual(len(worker2._finishedFetchers), 0,
-                             "_finishedFetchers must be cleared after success")
+                             "_finishedFetchers must be cleared by releaseFinishedFetchers()")
         finally:
             gc.set_threshold(*oldThresholds)
             gc.collect()

--- a/tests/test_logviewcomposite.py
+++ b/tests/test_logviewcomposite.py
@@ -106,6 +106,22 @@ class TestLogViewCompositeMerge(TestBase):
 
         self.assertIsNot(batch, self._logView.data)
 
+    def testLogViewNeverAliasesWorkerAllLogs(self):
+        """The view must not alias the worker's _allLogs list either: the view
+        mutates self.data in place (local-change rows, clear()) while the
+        worker concurrently reads and clears _allLogs — aliasing corrupts
+        both sides."""
+        self._emit([self._commit("a", 10)])
+        self._emit([self._commit("b", 5)])
+
+        # The second emission passes (allLogs, insertPositions); the view
+        # must have taken a copy, not the worker's list object.
+        self.assertIsNot(self._allLogs, self._logView.data)
+        self.assertEqual(
+            [c.sha1[0] for c in self._allLogs],
+            [c.sha1[0] for c in self._logView.data],
+            "contents must match despite the copy")
+
     def testSecondBatchMergesInOrder(self):
         c1 = self._commit("a", 10)
         c2 = self._commit("b", 30)

--- a/tests/test_logwindow.py
+++ b/tests/test_logwindow.py
@@ -101,6 +101,29 @@ class TestLogWindow(TestLogWindowBase):
         self.window.cancel(True)
         self.processEvents()
 
+    def testSubmoduleAvailableReloadsLogView(self):
+        """Regression: the log view created during the LogWindow's own
+        construction never connected to submoduleAvailable (logWindow()
+        returns None mid-construction), so a finished submodule scan could
+        not reload the view into composite mode on first open of a repo.
+        """
+        self.waitForLoaded()
+
+        logview = self.window.ui.gitViewA.ui.logView
+        # keep app.submodules empty while toggling the setting so that
+        # compositeModeChanged does not trigger a reload itself
+        self.app._submodules = []
+        self.app.settings().setCompositeMode(True)
+        self.app._submodules = ["."]
+
+        spyBegin = QSignalSpy(logview.beginFetch)
+        self.app.submoduleAvailable.emit(["."], False)
+        self.processEvents()
+
+        self.assertEqual(1, spyBegin.count())
+        logview.fetcher.cancel(True)
+        self.processEvents()
+
     def testLocalChanges(self):
         self.waitForLoaded()
 

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -40,7 +40,23 @@ class TestPreferences(TestBase):
 
         QTest.mouseClick(self.preferences.ui.buttonBox.button(
             QDialogButtonBox.Ok), Qt.LeftButton)
+    def testSortDiffByFileDefaultsOff(self):
+        """The new checkbox exists on the General/Diff view page and
+        defaults to unchecked; saving the dialog persists its state."""
+        self.assertFalse(self.app.settings().sortDiffByFile())
 
+        # General tab is lazily initialized on first visit
+        self.preferences.ui.tabWidget.setCurrentWidget(
+            self.preferences.ui.tabGeneral)
+        self.processEvents()
+
+        self.assertFalse(self.preferences.ui.cbSortDiffByFile.isChecked())
+
+        self.preferences.ui.cbSortDiffByFile.setChecked(True)
+        self.preferences.save()
+
+        self.assertTrue(self.app.settings().sortDiffByFile())
+        self.app.settings().setSortDiffByFile(False)
     def testExecDestroysDialogInGuiThread(self):
         # exec() leaves the dialog owned by Python even when it has a parent,
         # so anything left to the cyclic collector is destroyed by whichever

--- a/tests/test_submoduleexecutor.py
+++ b/tests/test_submoduleexecutor.py
@@ -168,3 +168,79 @@ class TestSubmoduleExecutor(TestBase):
             # wait for result
             self.wait(100)
             mock.assert_any_call(None, "Hello, World!")
+
+
+class TestSubmoduleExecutorCancelReentrancy(TestBase):
+    """Regression tests for cancel()'s re-entrancy holes.
+
+    _terminateThread() pumps the GUI event loop while waiting for the
+    thread, so queued finished() handlers run re-entrantly — and
+    StatusFetcher.onFinished() re-submits, mutating _thread/_threads
+    underneath a running cancel(). The disconnects must therefore be
+    idempotent and the bookkeeping must not leave stale references.
+    """
+
+    def doCreateRepo(self):
+        pass
+
+    def testCancelToleratesAlreadyDisconnectedThread(self):
+        """cancel(force=True) must not raise when the thread's finished()
+        connection was already disconnected by a previous cancel pass."""
+        executor = SubmoduleExecutor()
+        executor.submit(["."], lambda *a: None)
+        thread = executor._thread
+
+        # simulate a previous cancel pass that already disconnected
+        # _onThreadFinished (e.g. via its force-cleanup loop)
+        thread.finished.disconnect(executor._onThreadFinished)
+
+        # must not raise
+        executor.cancel(True)
+
+        self.assertIsNone(executor._thread)
+        self.assertEqual(executor._threads, [])
+        self.processEvents()
+
+    def testCancelClearsStaleThreadReference(self):
+        """cancel(force=True) must clear _thread even when the thread
+        already finished but its queued finished() handlers (which clear
+        _thread) have not been delivered yet."""
+        executor = SubmoduleExecutor()
+        executor.submit(["."], lambda *a: None)
+        thread = executor._thread
+
+        # wait for the thread to finish WITHOUT pumping events, so the
+        # queued finished() handlers stay pending
+        thread.wait(5000)
+        self.assertFalse(thread.isRunning())
+        self.assertIsNotNone(executor._thread)
+
+        executor.cancel(True)
+
+        self.assertIsNone(executor._thread)
+        self.assertEqual(executor._threads, [])
+        self.processEvents()
+
+    def testCancelForceKeepsThreadSubmittedDuringTerminate(self):
+        """A thread submitted re-entrantly during cancel()'s terminate wait
+        must survive in _threads instead of being disconnected and cleared
+        by the same cancel pass."""
+        executor = SubmoduleExecutor()
+
+        def action(submodule, userData, cancelEvent):
+            # mimics StatusFetcher.onFinished re-fetching while
+            # _terminateThread pumps the event loop
+            executor.submit(["."], lambda *a: None)
+
+        executor.submit(["."], action)
+        executor.cancel(True)
+        self.processEvents()
+
+        # the re-entrantly submitted thread must still be tracked with its
+        # finished() connection intact (not disconnected behind our back)
+        for thread in executor._threads:
+            self.assertTrue(thread.isRunning() or thread.isFinished())
+
+        executor.cancel(True)
+        self.assertEqual(executor._threads, [])
+        self.processEvents()


### PR DESCRIPTION
## Summary

This PR fixes a set of thread-lifecycle and memory issues found while
debugging qgitc on a large composite repo (284 nested repos, ~625k
commits per load), plus a few correctness bugs discovered along the
way, and adds a small diff-view option.

### Memory leak: ~1.4 GB retained per reload (F5) in composite mode

`LogsFetcherQProcessWorker._fetchComposite()` never released
`_allLogs` / `_mergedLogs` / `_mergedRepoDirs` after a successful
fetch — cleanup only ran at the *start* of a fetch or on cancellation.
Since each fetch creates a fresh worker, and the worker's
`deleteLater()` is queued to a thread that no longer runs an event
loop, every completed worker retained its full commit set forever.

Measured on the repo above (offscreen repro, gc object counting):

| | before | after |
|---|---|---|
| Commit objects after 3 reloads | 2,253,299 (+751k/reload) | 751,106 (stable) |
| Working set after 3 reloads | 4.4 GB (+1.4 GB/reload) | 1.8 GB (stable) |

The data is now released when the fetch completes (rebinding, never
clearing in place, so queued signal payloads keep their references),
and again from the GUI thread's thread-finished handler as a safety
net for paths that skip the end-of-fetch release.

### Deadlocks / hangs / crashes

- **GIL deadlock** (82f017b, 94389aa, 4ec44e8): destroying QObjects in
  the logs worker thread (or pumping events from it) can deadlock
  against the GUI thread. Worker-side destruction is gone; finished
  fetchers are released from the GUI thread after the thread stops.
- **GUI freeze** (37769eb): `QGitProcess.communicate()` looped on
  `waitForFinished(50)`; if the child exited while `processEvents()`
  ran, the call returns False forever and the GUI thread spins at 100%
  CPU indefinitely. The loop now keys on the process state.
- **Process abort on window close** (f5a33a2): `SubmoduleExecutor.cancel()`
  disconnected thread signals non-idempotently. `_terminateThread()`
  pumps the event loop, so queued `finished` handlers (and
  `StatusFetcher.onFinished()`'s re-submit) run re-entrantly and can
  disconnect the same thread underneath a later cancel. The escaping
  `RuntimeError` killed the whole process — on my machine it
  deterministically aborted `test_app.testWindows` and silently
  skipped the remaining 756 tests of the suite. Disconnects are now
  idempotent, `_thread` is detached before the terminate wait, and the
  force-cleanup loop iterates a snapshot of the list.
- **Submodule scan hang** (2cf8db3): a failed `QProcess` start emits
  `errorOccurred`, never `finished`, so the scan thread blocked
  forever and the directory-walk fallback never ran. Also stops
  retaining the `QEventLoop` as an instance attribute (cross-thread
  destruction) and guards post-wait access with `Shiboken.isValid()`.

### Correctness

- **Composite mode never activated on first open of a repo**
  (4836d2a): the log view's `submoduleAvailable` connection was gated
  on `logWindow()`, which returns `None` while the `LogWindow` is
  still constructing itself — exactly when the main log view is
  created. The connection is now unconditional (the handler already
  no-ops for non-standalone views).
- **Cross-thread list aliasing** (26cb03c): `LogView` could end up
  aliasing the worker's `_allLogs` list, which the worker mutates
  concurrently; the view now always builds a new list.
- **Diff truncation** (eb69604): file diffs were not accumulated
  across `QProcess` output chunks, so large diffs could be cut off
  mid-file.
- **None/future committerDateTime** (1e8c050): the composite merge
  now treats a missing datetime as oldest and sorts future-dated
  commits (e.g. clock skew, 2050) to the end of the list.

### Feature

- **Sort diff view files by name** (8077843): new preference
  (General → Diff view, default off = git output order), with
  translated strings.

## Testing

- Full suite: **1354 tests, 0 failures** (the submodule-executor fix
  alone unblocked 756 tests that were previously skipped because the
  suite process aborted mid-run).
- New regression tests: composite data release, submodule-scan start
  failure / event-loop retention, log-view composite reload,
  submodule-executor cancel re-entrancy (3 cases).
- Memory behavior verified with an offscreen repro harness on a
  284-repo / 625k-commit composite repo, aligned with the affected
  user's settings.